### PR TITLE
restore original graphical settings after plotting jpg with zero margin

### DIFF
--- a/digitize/R/functions.r
+++ b/digitize/R/functions.r
@@ -9,7 +9,7 @@ ReadImg = function(fname)
 {
 	img <- readJPEG(fname)
   op <- par(mar=c(0,0,0,0))
-  on.exit(op)
+  on.exit(par(op))
 	plot.new()
 	rasterImage(img,0,0,1,1)
 }


### PR DESCRIPTION
Original graphical settings are now saved prior to plotting the jpg image without no margin and restored afterwards so that no new graphical device needs to be opend to plot with axes again.
